### PR TITLE
Work with Adaptive Sync enabled: keep the hardware cursor visible

### DIFF
--- a/App/Sources/HiDPIDisplayApp.swift
+++ b/App/Sources/HiDPIDisplayApp.swift
@@ -902,6 +902,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
+        // 30s backstop for the deep Adaptive Sync mirror forming without a
+        // notification we acted on. Cheap no-op while the target is online.
+        if isActive && realMonitor != nil {
+            repinIfDeepMirrorFormed()
+        }
+
         // Case 1b: Orphaned virtual display exists (monitor gone, but isActive is false)
         // This can happen if mirror failed or app state got out of sync
         if !isActive && realMonitor == nil && hasOrphanedVirtualDisplay() {
@@ -1035,12 +1041,78 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
         debugLog("Mirror link broken — re-attaching \(currentVirtualID) -> \(physical) without rebuild")
         let manager = VirtualDisplayManager.shared()
-        let ok = manager.mirrorDisplay(currentVirtualID, toDisplay: physical, atRate: getDisplayRefreshRate(physical))
+        let rate = getDisplayRefreshRate(physical)
+        let ok = manager.mirrorDisplay(currentVirtualID, toDisplay: physical, atRate: rate)
         debugLog("Re-attach mirror result: \(ok)")
         if ok {
             targetExternalDisplayID = physical
+            scheduleAdaptiveSyncRepin(target: physical, rate: rate)
         }
         return ok
+    }
+
+    /// On an Adaptive Sync panel, re-assert the fixed native mode AFTER the
+    /// mirror is (re)established. The mirror config re-modes the target into a
+    /// synthesized VRR mirror mode that hides the hardware cursor (issue #7).
+    ///
+    /// The trigger is load-bearing, and it is a STATE, not a delay: macOS
+    /// settles the mirror by dropping the target out of the online display
+    /// list (the "deep" hardware mirror). Re-pinning after that transition
+    /// completes restores a correct, visible cursor. Re-pinning while the
+    /// target is still online — whether immediately or on a fixed timer —
+    /// aborts the transition halfway and leaves the cursor drawn at the wrong
+    /// scale and position (all three variants verified on a G95NC with
+    /// Adaptive Sync on). So: poll until the target leaves the online list,
+    /// then re-pin; if it never leaves, do NOT touch the mode.
+    /// No-op for panels without Adaptive Sync. Generation-guarded like every
+    /// other delayed setup step.
+    func scheduleAdaptiveSyncRepin(target: CGDirectDisplayID, rate: Double) {
+        guard VirtualDisplayManager.shared().displayHasAdaptiveSync(target) else { return }
+        debugLog("Adaptive Sync panel detected — waiting for the deep mirror to settle before re-pinning")
+        pollAdaptiveSyncRepin(target: target, rate: rate, generation: setupGeneration, attempt: 1)
+    }
+
+    private func pollAdaptiveSyncRepin(target: CGDirectDisplayID, rate: Double, generation: Int, attempt: Int) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+            guard let self = self, generation == self.setupGeneration else {
+                debugLog("Adaptive Sync re-pin superseded by newer setup, skipping")
+                return
+            }
+            guard self.isActive, CGDisplayMirrorsDisplay(target) == self.currentVirtualID else {
+                debugLog("Adaptive Sync re-pin: mirror no longer active, skipping")
+                return
+            }
+            if self.displayIsOnline(target) {
+                if attempt < 60 {  // up to ~2 minutes
+                    self.pollAdaptiveSyncRepin(target: target, rate: rate,
+                                               generation: generation, attempt: attempt + 1)
+                } else {
+                    debugLog("Adaptive Sync re-pin: target \(target) never left the online list after \(attempt) checks — leaving mode alone")
+                }
+                return
+            }
+            debugLog("Adaptive Sync deep mirror settled after \(attempt * 2)s — re-pinning fixed mode")
+            let ok = VirtualDisplayManager.shared().reassertFixedMode(onDisplay: target, atRate: rate)
+            debugLog("Adaptive Sync re-pin result: \(ok)")
+        }
+    }
+
+    /// Event-driven companion to the setup-time poll above: macOS can
+    /// reorganize the mirror into the deep (offline) hardware clone at ANY
+    /// point, not just during setup — e.g. after the panel renegotiates its
+    /// link — and that state hides the cursor until the fixed mode is
+    /// re-asserted. Going offline fires a display-change notification, so this
+    /// runs from the notification handler: if our Adaptive Sync target is
+    /// offline but still mirroring us, re-pin. No-ops in the online (shallow
+    /// mirror) state, which needs no repair.
+    func repinIfDeepMirrorFormed() {
+        guard isActive, currentVirtualID != 0, targetExternalDisplayID != 0,
+              CGDisplayMirrorsDisplay(targetExternalDisplayID) == currentVirtualID,
+              !displayIsOnline(targetExternalDisplayID) else { return }
+        let manager = VirtualDisplayManager.shared()
+        guard manager.displayHasAdaptiveSync(targetExternalDisplayID) else { return }
+        _ = manager.reassertFixedMode(onDisplay: targetExternalDisplayID,
+                                      atRate: getDisplayRefreshRate(targetExternalDisplayID))
     }
 
     /// Re-apply the optional HDR and main-display preferences after the mirror
@@ -1084,6 +1156,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 // mirror (e.g. the monitor enumerated after the wake
                 // assessment gave up). Repair in place; no-op when intact.
                 ensureMirrorIntact()
+                // If this notification was the panel dropping into the deep
+                // (offline) Adaptive Sync mirror, restore the fixed mode.
+                repinIfDeepMirrorFormed()
             }
             return
         }
@@ -1170,6 +1245,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 return displayID
             }
         }
+
+        // With Adaptive Sync enabled in the monitor's OSD, macOS takes the
+        // hardware-mirror target out of the online display list entirely while
+        // our mirror is active. The mirror relationship is still queryable on
+        // the offline display, so check it before concluding the monitor was
+        // unplugged — otherwise every display-change notification reads as a
+        // disconnect and tears down a healthy setup.
+        if currentVirtualID != 0 && targetExternalDisplayID != 0 &&
+           CGDisplayMirrorsDisplay(targetExternalDisplayID) == currentVirtualID {
+            if verbose {
+                debugLog("Monitor \(targetExternalDisplayID) is offline but still mirrors our virtual display (Adaptive Sync hardware mirror) — treating as connected")
+            }
+            return targetExternalDisplayID
+        }
+
         if verbose {
             debugLog("No real physical monitor found")
         }
@@ -2104,11 +2194,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Native size unreadable or it publishes no rate at all (some panels
         // report 0 Hz for their only mode). Fall back to the old whole-list max.
+        // VRR modes are excluded here too — their advertised (maximum) rate is
+        // one the pin can't hold the panel at, so handing it back would leave
+        // the virtual source and the panel at different rates.
         let opts = [kCGDisplayShowDuplicateLowResolutionModes: kCFBooleanTrue] as CFDictionary
         guard let modes = CGDisplayCopyAllDisplayModes(displayID, opts) as? [CGDisplayMode] else {
             return 60.0
         }
-        let rates = modes.compactMap { $0.refreshRate > 0 ? $0.refreshRate : nil }
+        let rates = modes.compactMap { mode -> Double? in
+            guard mode.refreshRate > 0, !VDMDisplayModeIsVRR(displayID, mode) else { return nil }
+            return mode.refreshRate
+        }
         return rates.max() ?? 60.0
     }
 
@@ -2124,10 +2220,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
         // Same eligibility test the pin uses. A rate that only exists on a mode
         // the pin would skip is a rate we must not hand back, or the virtual
-        // source and the panel end up running at different rates.
+        // source and the panel end up running at different rates. That includes
+        // VRR (Adaptive Sync) modes: with Adaptive Sync on in the monitor's OSD
+        // the top rate may exist only as a variable mode, and pinning that mode
+        // breaks the hardware cursor (issue #7).
         let rates = modes.compactMap { mode -> Double? in
             guard mode.isUsableForDesktopGUI(), mode.isNativeGrid(nativeWidth, nativeHeight),
-                  mode.refreshRate > 0 else { return nil }
+                  mode.refreshRate > 0,
+                  !VDMDisplayModeIsVRR(displayID, mode) else { return nil }
             return mode.refreshRate
         }
         return Array(Set(rates)).sorted()
@@ -2185,7 +2285,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let modes = (CGDisplayCopyAllDisplayModes(displayID, opts) as? [CGDisplayMode]) ?? []
         let atNative = nativeRefreshRates(displayID).map { Int($0.rounded()) }
         let anyRates = Set(modes.compactMap { $0.refreshRate > 0 ? Int($0.refreshRate.rounded()) : nil }).sorted()
-        debugLog("Panel \(displayID): native \(nativeWidth)x\(nativeHeight), rates at native \(atNative) Hz, all rates \(anyRates) Hz")
+        let vrrCount = modes.filter { VDMDisplayModeIsVRR(displayID, $0) }.count
+        debugLog("Panel \(displayID): native \(nativeWidth)x\(nativeHeight), fixed rates at native \(atNative) Hz, all rates \(anyRates) Hz, adaptive sync \(vrrCount > 0 ? "ON (\(vrrCount) VRR modes)" : "off")")
     }
 
     func createVirtualDisplayAsync(config: PresetConfig, generation: Int) {
@@ -2279,6 +2380,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             targetExternalDisplayID = externalID  // Track target for disconnect detection
             UserDefaults.standard.set(0, forKey: kMirrorFailureCountKey)  // Reset failure counter
             saveMonitorFingerprint(externalID)
+            scheduleAdaptiveSyncRepin(target: externalID, rate: pinRate)
             StatusWindowController.shared.updateStatus("HiDPI enabled: \(config.logicalWidth)x\(config.logicalHeight)")
             debugLog(">>> HiDPI setup complete, monitoring for disconnect")
 
@@ -2423,6 +2525,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return best.id
         }
 
+        // Same Adaptive Sync fallback as findRealPhysicalMonitor: the active
+        // hardware-mirror target is offline (not enumerated) but still ours.
+        if currentVirtualID != 0 && targetExternalDisplayID != 0 &&
+           CGDisplayMirrorsDisplay(targetExternalDisplayID) == currentVirtualID {
+            debugLog("  -> Mirror target \(targetExternalDisplayID) offline but mirror intact (Adaptive Sync) — using it")
+            return targetExternalDisplayID
+        }
+
         debugLog("  -> No external display found")
         return nil
     }
@@ -2456,6 +2566,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func connectedMonitorMatchesSavedPreset() -> Bool {
         guard UserDefaults.standard.object(forKey: kBoundMonitorVendorKey) != nil else {
+            return true
+        }
+
+        // An offline-but-mirrored target (Adaptive Sync hardware mirror) can't
+        // be fingerprinted from the online list, but it IS the monitor the
+        // preset was applied to — we set the mirror up on it.
+        if currentVirtualID != 0 && targetExternalDisplayID != 0 &&
+           CGDisplayMirrorsDisplay(targetExternalDisplayID) == currentVirtualID {
             return true
         }
 

--- a/App/Sources/VirtualDisplayManager.h
+++ b/App/Sources/VirtualDisplayManager.h
@@ -14,6 +14,16 @@ BOOL VDMNativePixelSize(CGDirectDisplayID displayID,
                         size_t * _Nullable outWidth,
                         size_t * _Nullable outHeight);
 
+/// Whether a display mode is variable-refresh (Adaptive Sync / ProMotion).
+/// With Adaptive Sync enabled in a monitor's OSD, macOS marks the top-rate
+/// modes as VRR; they report the same size and (maximum) refresh rate as fixed
+/// modes, so this is the only way to tell them apart. Both the refresh-rate
+/// picker and the mirror pin must skip VRR modes: mirroring a fixed-rate
+/// virtual source onto a variable-rate panel glitches the hardware cursor
+/// plane (issue #7). Resolved from SkyLight at runtime; returns NO (fixed)
+/// when the symbol is unavailable, matching pre-fix behavior.
+BOOL VDMDisplayModeIsVRR(CGDirectDisplayID displayID, CGDisplayModeRef _Nullable mode);
+
 @interface VirtualDisplayManager : NSObject
 
 /// Shared instance
@@ -62,6 +72,20 @@ BOOL VDMNativePixelSize(CGDirectDisplayID displayID,
 - (BOOL)mirrorDisplay:(CGDirectDisplayID)sourceDisplayID
             toDisplay:(CGDirectDisplayID)targetDisplayID
                atRate:(double)refreshRate;
+
+/// Whether the panel advertises any Adaptive Sync (VRR) modes, i.e. Adaptive
+/// Sync is enabled in the monitor's OSD.
+- (BOOL)displayHasAdaptiveSync:(CGDirectDisplayID)displayID;
+
+/// Re-assert the fixed-rate native mode on a mirrored Adaptive Sync panel.
+/// The mirror call re-modes the target into a synthesized VRR mirror mode
+/// that breaks the hardware cursor (issue #7); applying the fixed mode on top
+/// of the SETTLED mirror repairs it. Call only once the target has dropped
+/// out of the online display list (the deep hardware mirror forming) —
+/// re-pinning while it is still online aborts that transition and leaves the
+/// cursor drawn at the wrong scale and position.
+/// Returns YES if the panel is (already or now) in the intended fixed mode.
+- (BOOL)reassertFixedModeOnDisplay:(CGDirectDisplayID)displayID atRate:(double)refreshRate;
 
 /// Stop mirroring for a display
 /// @param displayID The display to stop mirroring

--- a/App/Sources/VirtualDisplayManager.m
+++ b/App/Sources/VirtualDisplayManager.m
@@ -30,6 +30,9 @@ static id _windowObserver = nil;
 }
 @end
 
+// Defined in the HDR section below; also used for VRR mode detection.
+static void *VDMSkyLightHandle(void);
+
 /// Read a 16-bit fixed-point chromaticity value from a nested CF dictionary.
 /// DisplayAttributes stores chromaticity as integers in [0, 65536] range.
 static CGFloat cfDictGetFixed16(CFDictionaryRef dict, CFStringRef key) {
@@ -393,6 +396,27 @@ BOOL VDMNativePixelSize(CGDirectDisplayID displayID, size_t *outWidth, size_t *o
     return found;
 }
 
+// SkyLight's per-mode VRR query. The mode number it takes is the CGS mode
+// index, which CGDisplayModeGetIODisplayModeID returns on Apple Silicon.
+// On Intel the two ID spaces may differ, but the function bounds-checks the
+// index against the display's mode table (confirmed by disassembly) and
+// returns false out of range — i.e. "fixed", the safe pre-fix behavior.
+typedef bool (*SLSIsDisplayModeVRRFn)(int displayID, int modeNum);
+
+BOOL VDMDisplayModeIsVRR(CGDirectDisplayID displayID, CGDisplayModeRef mode) {
+    if (!mode) return NO;
+    static SLSIsDisplayModeVRRFn fn = NULL;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        fn = (SLSIsDisplayModeVRRFn)dlsym(VDMSkyLightHandle(), "SLSIsDisplayModeVRR");
+        if (!fn) {
+            NSLog(@"VDM: SLSIsDisplayModeVRR unavailable — treating all modes as fixed-rate");
+        }
+    });
+    if (!fn) return NO;
+    return fn((int)displayID, CGDisplayModeGetIODisplayModeID(mode)) ? YES : NO;
+}
+
 /// Pick the mode to pin the physical panel to before mirroring.
 ///
 /// Resolution wins over refresh rate. Pinning below the native pixel grid to
@@ -401,10 +425,19 @@ BOOL VDMNativePixelSize(CGDirectDisplayID displayID, size_t *outWidth, size_t *o
 /// limited links hit this constantly: a panel that does native at 60 Hz but
 /// only half-height at 120 Hz used to get pinned to the half-height mode.
 ///
+/// Variable-refresh (Adaptive Sync) modes are never preferred. With Adaptive
+/// Sync enabled in the monitor's OSD, macOS marks the panel's top-rate modes
+/// as VRR, and they are indistinguishable from fixed modes by size and rate
+/// alone — so the pin used to land on one, leaving the panel in variable
+/// scanout while mirroring a fixed-rate virtual source. That combination
+/// glitches the hardware cursor plane (the disappearing cursor of issue #7).
+///
 /// Order of preference:
-///   1. native pixel grid at the requested rate
-///   2. native pixel grid at its own highest rate
-///   3. largest mode at the requested rate (only if native size is unknown)
+///   1. native pixel grid at the requested rate, fixed-rate
+///   2. native pixel grid at its own highest fixed rate
+///   3. native pixel grid at the requested rate, VRR (only if native has no
+///      fixed mode at all — keeps today's behavior rather than downscaling)
+///   4. largest fixed mode at the requested rate (only if native size is unknown)
 ///
 /// Returns NULL if nothing matches. Caller owns the returned mode and must
 /// release it via CGDisplayModeRelease().
@@ -415,9 +448,10 @@ static CGDisplayModeRef CopyBestModeAtRate(CGDirectDisplayID displayID, double r
     size_t nativeW = 0, nativeH = 0;
     BOOL haveNative = VDMNativePixelSizeInModes(modes, &nativeW, &nativeH);
 
-    CGDisplayModeRef nativeAtRate = NULL;   // native grid, requested rate
-    CGDisplayModeRef nativeFastest = NULL;  // native grid, highest rate
-    CGDisplayModeRef anyAtRate = NULL;      // last resort: biggest at requested rate
+    CGDisplayModeRef nativeAtRate = NULL;    // native grid, requested rate, fixed
+    CGDisplayModeRef nativeFastest = NULL;   // native grid, highest fixed rate
+    CGDisplayModeRef nativeVRRAtRate = NULL; // native grid, requested rate, VRR
+    CGDisplayModeRef anyAtRate = NULL;       // last resort: biggest fixed at requested rate
     double nativeFastestRate = -1;
     size_t anyAtRatePixels = 0;
 
@@ -435,8 +469,14 @@ static CGDisplayModeRef CopyBestModeAtRate(CGDirectDisplayID displayID, double r
 
         size_t pw = CGDisplayModeGetPixelWidth(mode);
         size_t ph = CGDisplayModeGetPixelHeight(mode);
+        BOOL isNativeSize = haveNative && pw == nativeW && ph == nativeH;
 
-        if (haveNative && pw == nativeW && ph == nativeH) {
+        if (VDMDisplayModeIsVRR(displayID, mode)) {
+            if (isNativeSize && rateMatches && !nativeVRRAtRate) nativeVRRAtRate = mode;
+            continue;
+        }
+
+        if (isNativeSize) {
             if (rateMatches && !nativeAtRate) nativeAtRate = mode;
             // nativeFastestRate is seeded at -1, so a panel that reports 0 Hz
             // for its native timing still lands here rather than falling
@@ -456,9 +496,15 @@ static CGDisplayModeRef CopyBestModeAtRate(CGDirectDisplayID displayID, double r
     CGDisplayModeRef best = nativeAtRate;
     if (!best) best = nativeFastest;
     if (best && best != nativeAtRate) {
-        NSLog(@"VDM: Panel %u has no %.1f Hz mode at native %zux%zu — keeping native at %.1f Hz "
+        NSLog(@"VDM: Panel %u has no fixed %.1f Hz mode at native %zux%zu — keeping native at %.1f Hz "
               @"instead of dropping resolution", displayID, refreshRate, nativeW, nativeH,
               CGDisplayModeGetRefreshRate(best));
+    }
+    if (!best && nativeVRRAtRate) {
+        NSLog(@"VDM: WARN - Panel %u offers no fixed-rate mode at native %zux%zu, pinning the VRR "
+              @"mode at %.1f Hz (cursor may glitch — consider disabling Adaptive Sync)",
+              displayID, nativeW, nativeH, refreshRate);
+        best = nativeVRRAtRate;
     }
     if (!best && anyAtRate) {
         NSLog(@"VDM: WARN - Panel %u offers no native-size mode, falling back to largest mode at %.1f Hz",
@@ -469,6 +515,22 @@ static CGDisplayModeRef CopyBestModeAtRate(CGDirectDisplayID displayID, double r
     CGDisplayModeRef retained = best ? (CGDisplayModeRef)CGDisplayModeRetain(best) : NULL;
     CFRelease(modes);
     return retained;
+}
+
+/// Whether the panel currently advertises any variable-refresh modes, i.e.
+/// Adaptive Sync is enabled in the monitor's OSD. macOS handles mirroring onto
+/// such a panel differently (see mirrorDisplay:toDisplay:atRate:).
+static BOOL VDMDisplayHasVRRModes(CGDirectDisplayID displayID) {
+    CFArrayRef modes = VDMCopyDesktopModes(displayID);
+    if (!modes) return NO;
+    BOOL found = NO;
+    CFIndex count = CFArrayGetCount(modes);
+    for (CFIndex i = 0; i < count && !found; i++) {
+        CGDisplayModeRef mode = (CGDisplayModeRef)CFArrayGetValueAtIndex(modes, i);
+        found = VDMDisplayModeIsVRR(displayID, mode);
+    }
+    CFRelease(modes);
+    return found;
 }
 
 /// Put the target display back into `mode` after a failed mirror attempt so
@@ -510,6 +572,15 @@ static void VDMRestorePinnedMode(CGDirectDisplayID displayID, CGDisplayModeRef m
     // in one config block conflicts (the mirror call resets target mode and
     // rejects the whole config). Doing it first ensures the panel is in a
     // stable fixed scanout when the mirror call attaches it to the source.
+    //
+    // NOTE: on Adaptive Sync panels the mirror call still replaces this mode
+    // with a synthesized VRR mirror mode. That is repaired by a LATER re-pin
+    // (reassertFixedModeOnDisplay:atRate:) that the caller issues once the
+    // target has dropped out of the online display list — NOT here.
+    // Re-pinning while the target is still online (immediately or on a
+    // timer) aborts WindowServer's mirror transition halfway and leaves the
+    // hardware cursor drawn at the wrong scale and position (verified on a
+    // G95NC with Adaptive Sync on).
     if (refreshRate > 0) {
         CGDisplayModeRef pinMode = CopyBestModeAtRate(targetDisplayID, refreshRate);
         if (pinMode) {
@@ -572,16 +643,84 @@ static void VDMRestorePinnedMode(CGDirectDisplayID displayID, CGDisplayModeRef m
     // perceive the difference visually.
     CGDisplayModeRef actual = CGDisplayCopyDisplayMode(targetDisplayID);
     if (actual) {
-        NSLog(@"VDM: Mirror success — target %u now at %zux%zu @ %.1f Hz",
+        NSLog(@"VDM: Mirror success — target %u now at %zux%zu @ %.1f Hz (%@, mode %d, online=%d)",
               targetDisplayID,
               CGDisplayModeGetWidth(actual),
               CGDisplayModeGetHeight(actual),
-              CGDisplayModeGetRefreshRate(actual));
+              CGDisplayModeGetRefreshRate(actual),
+              VDMDisplayModeIsVRR(targetDisplayID, actual) ? @"VRR" : @"fixed",
+              CGDisplayModeGetIODisplayModeID(actual),
+              CGDisplayIsOnline(targetDisplayID));
         CGDisplayModeRelease(actual);
     } else {
         NSLog(@"VDM: Mirror success (could not read back target mode)");
     }
     return YES;
+}
+
+- (BOOL)displayHasAdaptiveSync:(CGDirectDisplayID)displayID {
+    return VDMDisplayHasVRRModes(displayID);
+}
+
+- (BOOL)reassertFixedModeOnDisplay:(CGDirectDisplayID)displayID atRate:(double)refreshRate {
+    CGDisplayModeRef pinMode = CopyBestModeAtRate(displayID, refreshRate);
+    if (!pinMode) {
+        NSLog(@"VDM: Re-pin: no fixed mode found on display %u at %.1f Hz", displayID, refreshRate);
+        return NO;
+    }
+
+    CGDisplayModeRef current = CGDisplayCopyDisplayMode(displayID);
+    BOOL alreadyPinned = current &&
+        CGDisplayModeGetIODisplayModeID(current) == CGDisplayModeGetIODisplayModeID(pinMode);
+    if (current) CGDisplayModeRelease(current);
+    if (alreadyPinned) {
+        // Steady-state no-op: the periodic backstop lands here every 30s
+        // while the deep mirror is pinned, so don't log.
+        CGDisplayModeRelease(pinMode);
+        return YES;
+    }
+
+    // Enforce the contract from the header: re-pinning while the target is
+    // still in the online list aborts the mirror transition halfway and
+    // leaves the cursor drawn at the wrong scale and position.
+    if (CGDisplayIsOnline(displayID)) {
+        NSLog(@"VDM: Re-pin: display %u is still online (mirror not settled) — refusing", displayID);
+        CGDisplayModeRelease(pinMode);
+        return NO;
+    }
+
+    NSLog(@"VDM: Re-pin: setting display %u to fixed mode %d (%zux%zu @ %.1f Hz)",
+          displayID, CGDisplayModeGetIODisplayModeID(pinMode),
+          CGDisplayModeGetWidth(pinMode), CGDisplayModeGetHeight(pinMode),
+          CGDisplayModeGetRefreshRate(pinMode));
+
+    BOOL ok = NO;
+    CGDisplayConfigRef config;
+    if (CGBeginDisplayConfiguration(&config) == kCGErrorSuccess) {
+        CGError e = CGConfigureDisplayWithDisplayMode(config, displayID, pinMode, NULL);
+        if (e == kCGErrorSuccess) {
+            e = CGCompleteDisplayConfiguration(config, kCGConfigureForSession);
+            ok = (e == kCGErrorSuccess);
+            if (!ok) NSLog(@"VDM: WARN - Re-pin complete failed: %d", e);
+        } else {
+            NSLog(@"VDM: WARN - Re-pin configure failed: %d", e);
+            CGCancelDisplayConfiguration(config);
+        }
+    }
+    CGDisplayModeRelease(pinMode);
+
+    CGDisplayModeRef readback = CGDisplayCopyDisplayMode(displayID);
+    if (readback) {
+        NSLog(@"VDM: Re-pin result: display %u at %zux%zu @ %.1f Hz (%@, mode %d, online=%d)",
+              displayID,
+              CGDisplayModeGetWidth(readback), CGDisplayModeGetHeight(readback),
+              CGDisplayModeGetRefreshRate(readback),
+              VDMDisplayModeIsVRR(displayID, readback) ? @"VRR" : @"fixed",
+              CGDisplayModeGetIODisplayModeID(readback),
+              CGDisplayIsOnline(displayID));
+        CGDisplayModeRelease(readback);
+    }
+    return ok;
 }
 
 - (BOOL)stopMirroringForDisplay:(CGDirectDisplayID)displayID {

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ cd /path/to/HiDPIVirtualDisplay/App
 - Switching presets or disabling HiDPI briefly restarts the app (virtual displays can only be fully torn down when the process exits)
 - Refresh rate is auto-detected; if your monitor flickers, set it manually under Settings > Refresh Rate
 - Since 1.2.6, resolution wins over refresh rate. If your cable or port can't carry the panel's native resolution at the rate you picked, the app uses the fastest rate that *does* run at native instead of shrinking the desktop. Bandwidth-limited HDMI links hit this most often
+- Adaptive Sync (VRR) can stay enabled in the monitor's OSD, but the panel is always driven at a fixed rate while HiDPI is active — variable refresh isn't usable while mirroring a fixed-rate virtual display (it breaks the hardware cursor). If the monitor offers its top rate only as a variable mode, the app uses the fastest *fixed* rate at native resolution instead, which may be lower. Turn Adaptive Sync off in the OSD to guarantee the full rate
 - Mirroring resamples unless the preset's framebuffer matches the panel exactly. On a 7680x2160 panel only the 3840x1080 (2.0x) preset is a 1:1 mirror; every other preset trades a little sharpness for smaller text
 
 ## Troubleshooting


### PR DESCRIPTION
Fixes #7

## Problem
With Adaptive Sync enabled in the monitor's OSD, the hardware cursor disappears in HiDPI mirror mode. Two things go wrong:

1. macOS marks the panel's top-rate modes as VRR, but through the public CG API they are indistinguishable from fixed modes (same size, same reported max rate). The mirror pin could land on a VRR mode, and mirroring a fixed-rate virtual source onto a variable-rate panel glitches the hardware cursor plane.
2. macOS can also reorganize the mirror into a "deep" hardware clone that drops the target out of the online display list. That state hides the cursor - and the app misread the missing display as an unplug, tearing down a healthy setup on every display-change notification.

## Fix
- Detect VRR modes via SkyLight's `SLSIsDisplayModeVRR`, resolved at runtime like the existing HDR controls. A missing symbol degrades to the previous behavior; Intel is safe too (the function bounds-checks its mode index - see comments).
- The mirror pin and the refresh-rate picker now skip VRR modes, so the virtual display and the panel always agree on a fixed rate the pin can actually hold.
- When the deep mirror forms, re-assert the fixed native mode once the transition settles (setup-time poll, display-change notifications, and a 30s periodic backstop). Re-pinning while the target is still online aborts the transition halfway and draws the cursor at the wrong scale and position, so the settled (offline) state is a hard precondition enforced in `reassertFixedModeOnDisplay:atRate:`.
- An offline-but-mirrored target no longer reads as a disconnect.

## Verification
Tested on a Samsung Odyssey G9 57" (G95NC) on an M4 Max, macOS 27.0: with Adaptive Sync on, the cursor stays visible and correctly aligned; OSD Adaptive Sync toggles (and the transient dropouts they cause) no longer rebuild the setup; Adaptive Sync-off paths are unchanged - all new logic no-ops when the panel advertises no VRR modes.